### PR TITLE
Update to show no claps message on vote component

### DIFF
--- a/lib/shlinkedin_web/live/article_live/vote_component.html.leex
+++ b/lib/shlinkedin_web/live/article_live/vote_component.html.leex
@@ -6,6 +6,11 @@
 </div>
 
 <div class="p-5 pt-2 max-h-96 overflow-y-scroll">
+    <%= if @votes == [] do %>
+        <div class="text-center">
+            <p class="font-semibold text-gray-600  my-4">No claps here 😔</p>
+        </div>
+    <% end %>
     <%= for user <- @votes  do %>
 
     <div class="my-1 border-gray-100 border-b">


### PR DESCRIPTION
Added a message when opening an article with no claps

<img width="621" alt="Screenshot 2021-09-05 at 15 33 22" src="https://user-images.githubusercontent.com/90144560/132131083-e71dcb82-1686-4d5c-82cd-5a6aed3a0030.png">
