### PR TITLE
fix issue with default ad cost

### DIFF
--- a/lib/shlinkedin/ads/ad.ex
+++ b/lib/shlinkedin/ads/ad.ex
@@ -21,7 +21,7 @@ defmodule Shlinkedin.Ads.Ad do
     field(:overlay_color, :string)
     field(:removed, :boolean, default: false)
     field(:quantity, :integer, default: 1)
-    field(:price, Money.Ecto.Amount.Type, default: "100")
+    field(:price, Money.Ecto.Amount.Type, default: 100)
 
     timestamps()
   end


### PR DESCRIPTION
remove quotes to fix compilation error:
```
== Compilation error in file lib/shlinkedin/ads/ad.ex ==
** (ArgumentError) value "100" is invalid for type Money.Ecto.Amount.Type, can't set default
    (ecto 3.7.1) lib/ecto/schema.ex:2148: Ecto.Schema.validate_default!/2
    (ecto 3.7.1) lib/ecto/schema.ex:1883: Ecto.Schema.__field__/4
    lib/shlinkedin/ads/ad.ex:24: (module)
    (stdlib 3.15.2) erl_eval.erl:685: :erl_eval.do_apply/6
    (elixir 1.12.3) lib/kernel/parallel_compiler.ex:319: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```

fixes #68