### PR TITLE
fixes to Shlinkmail view for large screens

### DIFF
--- a/lib/shlinkedin_web/live/message_live/show.html.leex
+++ b/lib/shlinkedin_web/live/message_live/show.html.leex
@@ -1,9 +1,9 @@
    <!-- This example requires Tailwind CSS v2.0+ -->
-   <div class="max-w-7xl mx-auto" phx-hook="Message" id="shlinkmail">
+   <div class="max-w-7xl mx-auto bg-white" phx-hook="Message" id="shlinkmail">
 
        <div class="">
            <div
-               class="inline-flex border border-gray-200 px-6 pt-4 pb-4 w-full bg-white items-center fixed top-16 z-10">
+               class="inline-flex border border-gray-200 px-6 pt-4 pb-4 w-full bg-white items-center sticky top-16 z-10">
                <%= live_redirect to: Routes.message_index_path(@socket, :index) do %>
                <span
                    class="mr-4 inline-flex items-center p-1 border border-transparent rounded-full text-blue-500 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
@@ -53,7 +53,7 @@
 
            <%# Messages %>
 
-           <div class="px-3 pb-48 z-0 bg-white -mb-80 pt-20 min-h-screen">
+           <div class="px-3 pb-24 z-0 bg-white pt-6 min-h-screen">
                <%= if length(@messages) != 0 do %>
                <%= if @convo_length > @limit do %>
                <div class="text-sm text-gray-500 text-center">
@@ -158,7 +158,7 @@
 
 
 
-       <%= f = form_for :message, "#", [phx_hook: "SendMessage", phx_change: "update_message", phx_submit: "send_message", id: "send-message", class: "w-full mt-12 fixed sm:bottom-0 bottom-20 bg-white p-2 border-t shadow-t-sm", autocomplete: "off" ] %>
+       <%= f = form_for :message, "#", [phx_hook: "SendMessage", phx_change: "update_message", phx_submit: "send_message", id: "send-message", class: "w-full mt-12 sticky sm:bottom-0 bottom-20 bg-white p-2 border-t shadow-t-sm", autocomplete: "off" ] %>
 
        <%= if @some_text do %>
        <div class="inline-flex">

--- a/lib/shlinkedin_web/live/message_live/show.html.leex
+++ b/lib/shlinkedin_web/live/message_live/show.html.leex
@@ -143,7 +143,7 @@
        <%# Templates %>
        <%= unless @messages == [] do %>
        <div
-           class="fixed <%= if @some_text, do: "bottom-52 sm:bottom-32", else: "bottom-44 sm:bottom-24" %> w-full text-center">
+           class="sticky <%= if @some_text, do: "bottom-52 sm:bottom-32", else: "bottom-44 sm:bottom-24" %> w-full text-center">
            <div class="grid grid-cols-3 mx-4 gap-4">
                <%= for template <- @templates do %>
                <button id="<%=template.id%>" phx-click="template"


### PR DESCRIPTION
Fixed a couple CSS issues:
* message header is now contained by its parent
* new message form has width likewise contained
* same thing for new message templates

The main change was that I swapped `fixed` positioning for `sticky` since `fixed` makes the element ignore its parent's width. I also reduced some spacing, the padding could likely be reduced further.