### PR TITLE
don't show message header bar above site nav

### DIFF
--- a/lib/shlinkedin_web/live/message_live/show.html.leex
+++ b/lib/shlinkedin_web/live/message_live/show.html.leex
@@ -3,7 +3,7 @@
 
        <div class="">
            <div
-               class="inline-flex border border-gray-200 px-6 pt-4 pb-4 w-full bg-white items-center sticky top-16 z-10">
+               class="inline-flex border border-gray-200 px-6 pt-4 pb-4 w-full bg-white items-center sticky top-16">
                <%= live_redirect to: Routes.message_index_path(@socket, :index) do %>
                <span
                    class="mr-4 inline-flex items-center p-1 border border-transparent rounded-full text-blue-500 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">


### PR DESCRIPTION
remove z-index from message header bar. fixes issue with showing above site nav when expanded.