### PR TITLE
fix access checking logic for message templates

### DIFF
--- a/lib/shlinkedin_web/live/message_template_live/index.ex
+++ b/lib/shlinkedin_web/live/message_template_live/index.ex
@@ -5,8 +5,12 @@ defmodule ShlinkedinWeb.MessageTemplateLive.Index do
   alias Shlinkedin.Chat.MessageTemplate
 
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok, socket |> check_access() |> assign(:templates, list_templates())}
+  def mount(_params, session, socket) do
+    socket = is_user(session, socket)
+
+    {:ok,
+      check_access(socket)
+      |> assign(:templates, list_templates())}
   end
 
   @impl true


### PR DESCRIPTION
I copied the logic from the `mount()` function of `award_type_live` and that seems to fix it.

Previously, after setting my user account to `admin = true` in the database, I was seeing this error:

```
KeyError at GET /templates
key :profile not found in: %{flash: %{}, live_action: :index}
```