### PR TITLE
fix bottom padding for mobile news

### DIFF
--- a/lib/shlinkedin_web/live/home_live/index.html.leex
+++ b/lib/shlinkedin_web/live/home_live/index.html.leex
@@ -373,14 +373,13 @@
 
                 <%# Mobile News %>
                 <div id="mobile-news"
-                    class="sm:hidden mx-auto w-screen bg-white sm:rounded-lg border-b my-2">
+                    class="sm:hidden mx-auto w-screen bg-white sm:rounded-lg border-b my-2 py-5">
 
                     <div class="block sm:w-72 w-full">
 
-                        <div class="flex justify-between px-5 pt-5 pb-3">
+                        <div class="flex justify-between px-5 pb-3">
 
                             <p class="font-bold">ShlinkNews </p>
-
 
                         </div>
 


### PR DESCRIPTION
Proof:
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/463469/135725314-f008508d-9294-4ecc-b3a7-f4b556c9d75b.png">

Also tested desktop view, determined that they are rendered separately so this is unaffected.