### PR TITLE
Fix Author Profile Info in Posts details being truncated too early

### DIFF
--- a/lib/shlinkedin_web/live/post_live/post_header.ex
+++ b/lib/shlinkedin_web/live/post_live/post_header.ex
@@ -4,7 +4,7 @@ defmodule ShlinkedinWeb.PostLive.PostHeader do
 
   def render(assigns) do
     ~L"""
-    <div class="ml-2 sm:ml-4 mt-2 sm:mt-3">
+    <div class="ml-2 sm:ml-4 mt-2 sm:mt-3" style="width: 100%; overflow-x: hidden;">
     <div class="flex items-center">
         <div class="flex-shrink-0">
             <span class="inline-block relative">
@@ -14,7 +14,7 @@ defmodule ShlinkedinWeb.PostLive.PostHeader do
                     class="absolute bottom-0 right-0 block h-2 w-2 rounded-full ring-2 ring-white bg-green-400"></span>
             </span>
         </div>
-        <div class="ml-3 sm:ml-4 cursor-pointer w-64 text-gray-500 truncate overflow-hidden">
+        <div class="ml-3 sm:ml-4 cursor-pointer text-gray-500 truncate overflow-hidden">
 
 
 


### PR DESCRIPTION
This isn't a pretty fix, but if quick is desired, it's here. I'm no Elixir (nor really a CSS person) developer, so sorry for the lack of quality.

The issue was w-64 setting a width of 16em (so effectively 16 the width of a character). This attempts to get the width of the parent box with a semi-ugly hack.

Result:
![image](https://user-images.githubusercontent.com/8390674/148692632-05b4cc40-abf3-46cc-a3a5-cb9367c8707b.png)


Feel free to edit the PR.

P.S. I am the suika user on the instance.