### PR TITLE
fix: converts all `\n` to `<br>` in user bio before rendering

### DIFF
--- a/lib/shlinkedin_web/live/profile_live/show.html.leex
+++ b/lib/shlinkedin_web/live/profile_live/show.html.leex
@@ -140,8 +140,9 @@
                 <% end %>
                 <% else  %>
                 <div class="sm:flex items-start sm:text-left text-center text-sm">
-                    <span class="text-gray-700 italic"><%= @show_profile.summary  %></span>
-
+                  <p class="text-gray-700 italic">
+                    <%= @show_profile.summary |> String.split("\n", trim: false) |> Enum.intersperse(Phoenix.HTML.Tag.tag(:br)) %>
+                  </p>
                 </div>
                 <% end %>
 


### PR DESCRIPTION
## 🖕🏻🖕🏻 the problem
User bios on the profile page don't render any included newlines. If a bio _does_ have newlines, they show up pretty much everywhere else, just not on the front-end. Here are some screenshot:

## 👍🏻 in edit (good)

<p align="left">
    <img width="300" alt="in-edit" src="https://user-images.githubusercontent.com/2075200/180960756-d3d700f1-2e1d-43f2-b300-5e5c04575871.png">
</p>

You enter some content and make it look nice and organized

## 👍🏻 in database (good)
<p align="left">
    <img width="300" alt="in-database" src="https://user-images.githubusercontent.com/2075200/180960746-7a7332ef-24ed-42f0-9831-07ba0a1da659.png">
</p>

You click save, data gets written to the database, newlines are still there


## 👎🏻 on profile (bad)
<p align="left">
    <img width="300" alt="bad" src="https://user-images.githubusercontent.com/2075200/180960757-b8bcaa03-d344-4cba-81b1-e555dcf9251c.png">
</p>

You get redirected back to your profile page and are met with hot garbage


## 👍🏻  in pull request (good)
<p align="left">
    <img width="300" alt="good" src="https://user-images.githubusercontent.com/2075200/180960755-ae66fa55-860a-4abd-ae26-37d055ff7b94.png">
</p>

Because the bio is stored with it's new lines as "\n", when it's rendered each "\n" need to be converted to a `<br>`


## 🔁 the changes

This was my first experience with elixir and erlang...and it will probably be my last. I'm too stupid to figure out how it's supposed to make my life easier. As such, I just copypasta'd the first thing that worked for me and didn't write any tests. If you want to solve this a different way, be my guest, it won't hurt my feelings.

Love this site and keep hustling everyone, we'll get there one day.