### PR TITLE
changed master to main in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ in order to craft an excellent pull request:
 2. If you cloned a while ago, get the latest changes from upstream, and update your fork:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    git push
    ```
 


### PR DESCRIPTION
This is step 2 in the README

git checkout master
git pull upstream master
git push

Maybe this worked before when Github was in the process of its change, and you had both a master and a main, but if I clone today I think it should just say "main."  "git pull upstream master" would not work, and the fact that step 3 refers to main makes it confusing.

If you disagree, go ahead and close.

(Yes, this is an attempt to get on the contributor list with a minimal change :P)